### PR TITLE
refine estimator heuristics and quick planning ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,43 @@
 # LLM Cost Estimator
-  A project developed to predict the computational costs associated with training and inferencing large language models (LLMs). The tool utilizes various key model parameters such as FLOPs, number of parameters, memory bandwidth, and others to provide an accurate estimate of GPU usage, inference time, and overall training cost.
 
-## Features
+The LLM Cost Estimator is an interactive Next.js application that helps machine-learning practitioners quickly validate whether a large language model will fit into a particular GPU setup and how much it will cost to run. The calculator combines up-to-date GPU specifications, detailed VRAM breakdowns (weights, activations, KV cache and optimiser state), performance projections and cloud pricing guidance.
 
-- **GPU Memory Estimation**: Provide the number of parameters of an LLM and get an estimation of the total GPU memory required to run it.
-- **FLOPs Calculation**: Enter your model's architecture description (number of layers, sequence length, hidden dimensions, number of heads, etc.), and ProphetAI will output the estimated total FLOPs of the model.
-- **Inference Time Estimation**: ProphetAI can predict the inference time of your LLM on a specified GPU, factoring in memory bandwidth and software overhead.
-- **Training Cost Estimation**: By inputting the necessary details (including GPU hourly cost, number of epochs, and dataset size), you can receive an estimate of the overall cost of training your LLM.
+## Key capabilities
 
-## Limitations and Disclaimer
+- **Automatic Hugging Face introspection** – fetch a model configuration from the Hugging Face Hub and auto-populate parameter counts, hidden sizes, attention heads and precision defaults.
+- **Detailed VRAM analysis** – quantify memory consumption for model weights, activations, KV cache and optimiser state with a configurable execution mode (inference or training), precision, overhead factor and batch size.
+- **Hardware fit recommendations** – compare the required VRAM against a curated list of GPUs, highlight whether a selected GPU has enough headroom and propose the closest alternatives.
+- **Performance estimations** – estimate FLOPs per forward pass, tokens per second and milliseconds per token using the selected GPU’s compute throughput and an efficiency factor.
+- **Cloud cost calculator** – explore on-demand pricing across popular AWS, GCP, Azure and independent GPU providers, override hourly rates and receive a total cost projection for the planned runtime.
 
-The estimates provided are based on simplified models of computational requirements and costs. The actual requirements and costs can be higher due to a variety of factors not accounted for in these estimates, such as data loading time, network overhead, model serialization/deserialization time, potential additional costs like data transfer, storage, or CPU/RAM usage, and others.
+## Getting started
 
-Please use this tool as a rough guideline and always measure the actual requirements and costs by running your specific models on your target hardware and software stack.
+1. Install dependencies:
 
-## Contributions
+   ```bash
+   npm install
+   ```
 
-Contributions are welcome!
+2. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+3. Navigate to `http://localhost:3000` and search for a Hugging Face model such as `meta-llama/Llama-2-7b-hf`.
+
+## Testing
+
+Run the unit test suite to verify estimator calculations:
+
+```bash
+npm test
+```
+
+## Disclaimer
+
+The estimator uses analytical approximations of transformer memory footprints, throughput and pricing. Results should be treated as indicative; always validate with real workloads before committing to production deployments.
+
+## Contributing
+
+Pull requests that improve model coverage, pricing data or UX are very welcome. Please open an issue to discuss substantial changes before contributing.

--- a/src/estimator/__tests__/estimator.test.ts
+++ b/src/estimator/__tests__/estimator.test.ts
@@ -1,279 +1,139 @@
 import {
-  calculateMemory,
-  calculateFlops,
-  estimateModelSize,
-  estimateModelSizeT5,
-  estimateInferenceTime,
-  estimateTrainingCost,
-  recommendGPU,
-  // Config, // Config is an interface, not typically imported for tests unless used for type checking test data.
+  bitsToBytes,
+  calculateActivationMemoryGB,
+  calculateKvCacheMemoryGB,
+  calculateMemoryFromBillions,
+  calculateOptimizerMemoryGB,
+  calculateWeightMemoryGB,
+  estimateCloudCost,
+  estimateDecoderFlops,
+  estimateLlamaStyleArchitecture,
+  estimateMemory,
+  estimateThroughput,
+  estimateTransformerParameters,
+  recommendGpus,
 } from '../estimator';
 
-// Define Config interface locally for test data, or import if exportable and needed for explicit typing.
-interface Config {
-  vocab_size: number;
-  d_model: number;
-  n_head: number;
-  num_layers: number;
-  n_head_kv?: number; // Made optional to match usage in estimateModelSizeT5 if it can handle optional n_head_kv
-  d_ff: number;
-  n_positions: number;
-  num_decoder_layers: number;
-}
-
-describe('Estimator Functions', () => {
-  // Tests for calculateMemory
-  describe('calculateMemory', () => {
-    it('should correctly calculate memory for typical inputs', () => {
-      // 1B params, 32-bit (4 bytes) -> 1 * 10^9 * 4 / 1024^3 = 3.725 GB
-      expect(calculateMemory(1 * 10 ** 9, 32)).toBeCloseTo(3.725290298461914);
-      // 7B params, 16-bit (2 bytes) -> 7 * 10^9 * 2 / 1024^3 = 13.0385160446167
-      expect(calculateMemory(7 * 10 ** 9, 16)).toBeCloseTo(13.0385160446167);
-    });
-
-    it('should handle zero parameters', () => {
-      expect(calculateMemory(0, 32)).toBe(0);
-    });
-
-    it('should handle zero bytes (though unrealistic, should not crash)', () => {
-      expect(calculateMemory(1 * 10 ** 9, 0)).toBe(0);
-    });
+describe('Estimator utilities', () => {
+  it('converts bits to bytes', () => {
+    expect(bitsToBytes(32)).toBe(4);
+    expect(bitsToBytes(16)).toBe(2);
+    expect(bitsToBytes(4)).toBe(0.5);
   });
 
-  // Tests for calculateFlops
-  describe('calculateFlops', () => {
-    it('should correctly calculate FLOPs based on the formula', () => {
-      // Formula: 10 * numLayers * seqLength * hiddenDims^2 + 2 * seqLength * hiddenDims * vocabSize
-      const numLayers = 12;
-      const seqLength = 512;
-      const hiddenDims = 768;
-      const vocabSize = 30522;
-      const trulyExpectedFlops = 36262790201344;
-      // Verifying the manual calculation:
-      // Term1 = 10 * 12 * 512 * 768 * 768 = 36238786560000
-      // Term2 = 2 * 512 * 768 * 30522 = 24003641344
-      // Sum = Term1 + Term2 = 36262790201344
-
-      // This assertion now directly checks if the function returns the manually calculated correct value.
-      expect(calculateFlops(numLayers, seqLength, hiddenDims, vocabSize)).toBe(trulyExpectedFlops);
-      // The toBeCloseTo is redundant if toBe passes with the exact number, but keep for consistency or if floats were involved.
-      expect(calculateFlops(numLayers, seqLength, hiddenDims, vocabSize)).toBeCloseTo(trulyExpectedFlops);
-    });
+  it('computes weight memory in GB', () => {
+    const paramCount = 7 * 10 ** 9;
+    const fp16 = calculateWeightMemoryGB(paramCount, 16);
+    expect(fp16).toBeCloseTo((paramCount * 2) / 1024 ** 3);
   });
 
-  // Tests for estimateModelSize
-  describe('estimateModelSize', () => {
-    // vocab_size: number, hidden_size: number, n_head: number, n_layer: number, n_head_kv?: number | null
-    // total_params = vocab_size * hidden_size;
-    // effective_n_head_kv = n_head_kv ?? n_head;
-    // total_params += n_layer * (n_head * hidden_size * 3 + effective_n_head_kv * hidden_size * 2) * 2;
-    // total_params += n_layer * hidden_size * 4; (FFN)
-    // total_params += n_layer * hidden_size * 2; (LayerNorm)
-    it('should estimate model size with n_head_kv provided', () => {
-      const vocab_size = 30000;
-      const hidden_size = 768;
-      const n_head = 12;
-      const n_layer = 6;
-      const n_head_kv = 12; // Same as n_head for MHA
-      let expected = vocab_size * hidden_size; // Embeddings: 30000 * 768 = 23040000
-      expected += n_layer * (n_head * hidden_size * 3 + n_head_kv * hidden_size * 2) * 2; // Attention: 6 * (12*768*3 + 12*768*2) * 2 = 6 * (27648 + 18432) * 2 = 6 * 46080 * 2 = 552960
-      expected += n_layer * hidden_size * 4; // FFN: 6 * 768 * 4 = 18432
-      expected += n_layer * hidden_size * 2; // LayerNorm: 6 * 768 * 2 = 9216
-      // Corrected calculation:
-      // Embeddings: 30000 * 768 = 23,040,000
-      // Attention QKV (n_head * hs * 3): 12 * 768 * 3 = 27648. Output (n_head * hs): Not how it's usually counted here.
-      // The formula is: total_params += n_layer * ( (n_head * hidden_size * 3) /*QKV weights*/ + (n_head_kv * hidden_size * 2) /* This part of formula is unusual, usually it's for specific architectures like Llama for GQA, where Q is hs*hs, K,V are hs*kv_dim. The current formula is simplified */) * 2;
-      // Let's re-evaluate the formula in the code:
-      // total_params += n_layer * (n_head * hidden_size * 3 + effective_n_head_kv * hidden_size * 2) * 2;
-      // This seems to double count or is non-standard. Let's assume it means Q, K, V projections and output projection.
-      // A more standard calculation for self-attention might be: n_layer * ( (hidden_size * hidden_size * 3) /*Q,K,V weights*/ + (hidden_size * hidden_size) /*Output proj*/ )
-      // And for FFN: n_layer * (hidden_size * mlp_intermediate_size + mlp_intermediate_size * hidden_size) -> n_layer * (hidden_size * 4*hidden_size + 4*hidden_size * hidden_size)
-      // Given the formula in estimator.ts:
-      // Word Embeddings: 30000 * 768 = 23040000
-      // Self-attention: 6 * (12 * 768 * 3 + 12 * 768 * 2) * 2 = 6 * (27648 + 18432) * 2 = 6 * 46080 * 2 = 552960. This seems very low.
-      // The formula might be missing hidden_size in products: n_layer * ( (n_head * (hidden_size/n_head) * hidden_size * 3) + ... )
-      // Let's use the formula as written:
-      let calc = vocab_size * hidden_size; // 23040000
-      calc += n_layer * (n_head * hidden_size * 3 + n_head_kv * hidden_size * 2) * 2; // 6 * (12*768*3 + 12*768*2)*2 = 6 * (27648 + 18432)*2 = 6 * 46080 * 2 = 552960
-      calc += n_layer * hidden_size * 4; // 6 * 768 * 4 = 18432
-      calc += n_layer * hidden_size * 2; // 6 * 768 * 2 = 9216
-      // Total: 23040000 + 552960 + 18432 + 9216 = 23620608
-      // This value seems too small for a 6 layer model. The formula in estimator.ts might be a simplification that doesn't scale like real models.
-      // For the purpose of testing the function AS WRITTEN:
-      expect(estimateModelSize(vocab_size, hidden_size, n_head, n_layer, n_head_kv)).toBe(calc);
-    });
+  it('scales activation memory by mode', () => {
+    const params = 1 * 10 ** 9;
+    const inferenceActivations = calculateActivationMemoryGB(
+      params,
+      16,
+      'inference'
+    );
+    const trainingActivations = calculateActivationMemoryGB(
+      params,
+      16,
+      'training'
+    );
 
-    it('should estimate model size with n_head_kv as null (defaulting to n_head)', () => {
-      const vocab_size = 30000;
-      const hidden_size = 768;
-      const n_head = 12;
-      const n_layer = 6;
-      // n_head_kv is null, so effective_n_head_kv becomes n_head (12)
-      let calc = vocab_size * hidden_size;
-      calc += n_layer * (n_head * hidden_size * 3 + n_head * hidden_size * 2) * 2; // n_head_kv replaced by n_head
-      calc += n_layer * hidden_size * 4;
-      calc += n_layer * hidden_size * 2;
-      expect(estimateModelSize(vocab_size, hidden_size, n_head, n_layer, null)).toBe(calc);
-    });
-     it('should estimate model size with n_head_kv as undefined (defaulting to n_head)', () => {
-      const vocab_size = 30000;
-      const hidden_size = 768;
-      const n_head = 12;
-      const n_layer = 6;
-      let calc = vocab_size * hidden_size;
-      calc += n_layer * (n_head * hidden_size * 3 + n_head * hidden_size * 2) * 2;
-      calc += n_layer * hidden_size * 4;
-      calc += n_layer * hidden_size * 2;
-      expect(estimateModelSize(vocab_size, hidden_size, n_head, n_layer, undefined)).toBe(calc);
-    });
+    expect(trainingActivations).toBeGreaterThan(inferenceActivations);
+    expect(trainingActivations / inferenceActivations).toBeCloseTo(10);
   });
 
-  // Tests for estimateModelSizeT5
-  describe('estimateModelSizeT5', () => {
-    it('should estimate T5 model size with a sample config', () => {
-      const config: Config = {
-        vocab_size: 32128,
-        d_model: 768,
-        n_head: 12, // Not directly used in T5 original paper's param count, d_kv is used. But this config interface has it.
-        num_layers: 12, // Encoder layers
-        d_ff: 3072, // d_model * 4
-        n_positions: 512,
-        num_decoder_layers: 12, // Decoder layers
-        // n_head_kv: model.num_heads_kv || model.n_head_kv || model.num_attention_heads, // T5 usually has d_kv = d_model / num_heads
-      };
-      // The function estimateModelSizeT5 in estimator.ts has a specific structure:
-      // encoderLayersParams = config.d_model * config.vocab_size * 4 * config.d_model + ...
-      // This seems incorrect. d_model * vocab_size is embedding layer.
-      // A typical T5 parameter count is more like:
-      // Shared Embeddings: vocab_size * d_model
-      // Encoder: num_layers * (SelfAttention + FFN)
-      //   SelfAttention: (d_model * d_k * num_heads) * 3 (Q,K,V weights) + (d_model * d_model) (output proj) + LayerNorms
-      //   FFN: (d_model * d_ff + d_ff * d_model) + LayerNorm
-      // Decoder: num_layers * (SelfAttention + CrossAttention + FFN)
-      //   CrossAttention similar to SelfAttention
-      // LM Head: d_model * vocab_size (if not shared)
-      // Given the formula in estimator.ts:
-      // encoderLayersParams = d_model * vocab_size * 4 * d_model + d_model * vocab_size * d_ff + d_model * vocab_size * 2
-      // This formula is highly problematic. (d_model * vocab_size) is huge and repeated.
-      // For the purpose of testing the function AS WRITTEN, we must use its own logic.
-      let totalParams = 0;
-      const encoderLayersParams =
-        config.d_model * config.vocab_size * 4 * config.d_model +
-        config.d_model * config.vocab_size * config.d_ff +
-        config.d_model * config.vocab_size * 2;
-      totalParams += config.num_layers * encoderLayersParams;
-
-      const decoderLayersParams =
-        config.d_model * config.vocab_size * 4 * config.d_model +
-        config.d_model * config.vocab_size * config.d_ff * 2 +
-        config.d_model * config.vocab_size * 3;
-      totalParams += config.num_decoder_layers * decoderLayersParams;
-
-      const embeddingParams =
-        config.vocab_size * config.d_model +
-        config.n_positions * config.d_model;
-      totalParams += embeddingParams;
-      // This will result in an astronomically large number due to the formula structure.
-      // Expecting the function to return what its current (flawed) logic dictates.
-      expect(estimateModelSizeT5(config)).toBeCloseTo(totalParams);
+  it('computes kv cache memory', () => {
+    const kv = calculateKvCacheMemoryGB({
+      sequenceLength: 4096,
+      batchSize: 1,
+      numLayers: 32,
+      hiddenSize: 4096,
+      precisionBits: 16,
     });
+    expect(kv).toBeGreaterThan(1);
+    expect(kv).toBeLessThan(3);
   });
 
-  // Tests for estimateInferenceTime
-  describe('estimateInferenceTime', () => {
-    // flops (GFLOPs), gpu_tflops (TFLOPs), num_params (actual), memory_bandwidth (GB/s), overhead, bytes_per_param
-    const num_params = 3 * 10 ** 9; // 3B params
-    const overhead_factor = 1.0;
-    const bytes_per_param = 2; // FP16
-
-    it('should correctly calculate for a compute-bound scenario', () => {
-      const flops_gflops = 2000; // High GFLOPs for the operation
-      const gpu_tflops = 30;    // Moderate GPU TFLOPs
-      const memory_bandwidth_gbs = 500; // High memory bandwidth
-
-      const gpu_flops_val = gpu_tflops * 10 ** 12;
-      const compute_time = (flops_gflops * 10 ** 9) / gpu_flops_val; // (2000e9) / (30e12) = 2000/30000 = 0.0666s
-      const memory_bandwidth_bytes = memory_bandwidth_gbs * 1024 ** 3;
-      const memory_time = (num_params * bytes_per_param) / memory_bandwidth_bytes; // (3e9 * 2) / (500 * 1024^3) = 6e9 / 5.3687e11 = 0.0111s
-      // compute_time (0.0666) > memory_time (0.0111), so result is compute_time
-      const expected_time = Math.max(compute_time, memory_time) * overhead_factor;
-      expect(estimateInferenceTime(flops_gflops, gpu_tflops, num_params, memory_bandwidth_gbs, overhead_factor, bytes_per_param)).toBeCloseTo(expected_time);
-      expect(expected_time).toBeCloseTo(0.06666666666666667);
-    });
-
-    it('should correctly calculate for a memory-bound scenario', () => {
-      const flops_gflops = 100;  // Low GFLOPs for the operation
-      const gpu_tflops = 100;   // High GPU TFLOPs
-      const memory_bandwidth_gbs = 60; // Low memory bandwidth
-
-      const gpu_flops_val = gpu_tflops * 10 ** 12;
-      const compute_time = (flops_gflops * 10 ** 9) / gpu_flops_val; // (100e9) / (100e12) = 100/100000 = 0.001s
-      const memory_bandwidth_bytes = memory_bandwidth_gbs * 1024 ** 3;
-      const memory_time = (num_params * bytes_per_param) / memory_bandwidth_bytes; // (3e9 * 2) / (60 * 1024^3) = 6e9 / (60 * 1.0737e9) = 6e9 / 6.44245e10 = 0.0931s
-      // memory_time (0.0931) > compute_time (0.001), so result is memory_time
-      const expected_time = Math.max(compute_time, memory_time) * overhead_factor;
-      expect(estimateInferenceTime(flops_gflops, gpu_tflops, num_params, memory_bandwidth_gbs, overhead_factor, bytes_per_param)).toBeCloseTo(expected_time);
-      expect(expected_time).toBeCloseTo(0.09313225746154785);
-    });
-
-    it('should apply overhead factor correctly', () => {
-      const overhead = 1.5;
-      const flops_gflops = 2000;
-      const gpu_tflops = 30;
-      const memory_bandwidth_gbs = 500;
-      const compute_time_no_overhead = (2000 * 10**9) / (30 * 10**12); // 0.0666...
-      const memory_time_no_overhead = (3 * 10**9 * 2) / (500 * 1024**3); // 0.0111...
-      const expected_time_with_overhead = Math.max(compute_time_no_overhead, memory_time_no_overhead) * overhead;
-      expect(estimateInferenceTime(flops_gflops, gpu_tflops, num_params, memory_bandwidth_gbs, overhead, bytes_per_param)).toBeCloseTo(expected_time_with_overhead);
-    });
+  it('computes optimizer memory for adam', () => {
+    const params = 3 * 10 ** 9;
+    const optimizerGb = calculateOptimizerMemoryGB(params, 16, 'adamw');
+    const weightGb = calculateWeightMemoryGB(params, 16);
+    expect(optimizerGb).toBeCloseTo(weightGb * 4);
   });
 
-  // Tests for estimateTrainingCost
-  describe('estimateTrainingCost', () => {
-    // inference_gflops_per_sequence, gpu_tflops, num_params, memory_bandwidth, overhead_factor, gpu_hourly_cost, num_epochs, dataset_size, model_precision_bits
-    it('should correctly calculate training cost', () => {
-      const inference_gflops = 1000; // GFLOPs for 1 fwd pass
-      const gpu_tflops = 80;
-      const num_params_actual = 6 * 10 ** 9; // 6B
-      const memory_bandwidth_gbs = 700;
-      const overhead = 1.2;
-      const gpu_hourly_cost = 2.5; // $
-      const num_epochs = 3;
-      const dataset_size = 100000; // sequences
-      const model_precision_bits = 16; // FP16
-
-      const training_gflops = inference_gflops * 3;
-      const model_b = model_precision_bits / 8;
-      const grad_b = model_precision_bits / 8;
-      const opt_b = 8;
-      const bytes_per_param_training = model_b + grad_b + opt_b; // 2 + 2 + 8 = 12
-
-      const time_per_item = estimateInferenceTime(training_gflops, gpu_tflops, num_params_actual, memory_bandwidth_gbs, overhead, bytes_per_param_training);
-      const total_time_seconds = time_per_item * dataset_size * num_epochs;
-      const total_time_hours = total_time_seconds / 3600;
-      const expected_cost = total_time_hours * gpu_hourly_cost;
-
-      expect(estimateTrainingCost(inference_gflops, gpu_tflops, num_params_actual, memory_bandwidth_gbs, overhead, gpu_hourly_cost, num_epochs, dataset_size, model_precision_bits)).toBeCloseTo(expected_cost);
+  it('provides a full memory breakdown', () => {
+    const breakdown = estimateMemory({
+      parameterCount: 13 * 10 ** 9,
+      weightPrecisionBits: 16,
+      mode: 'inference',
+      hiddenSize: 5120,
+      numLayers: 40,
+      sequenceLength: 4096,
+      batchSize: 1,
     });
+
+    expect(breakdown.weightsGB).toBeGreaterThan(20);
+    expect(breakdown.kvCacheGB).toBeGreaterThan(3);
+    expect(breakdown.totalGB).toBeGreaterThan(breakdown.baseTotalGB);
   });
 
-  // Tests for recommendGPU
-  describe('recommendGPU', () => {
-    it('should recommend GTX 1060 for low memory and flops', () => {
-      expect(recommendGPU(7, 0.5 * 1e9)).toBe('Minimum recommendation: NVIDIA GTX 1060 6GB');
-      expect(recommendGPU(8, 1 * 1e9)).toBe('Minimum recommendation: NVIDIA GTX 1060 6GB');
+  it('estimates throughput with efficiency factor', () => {
+    const throughput = estimateThroughput({
+      parameterCount: 7 * 10 ** 9,
+      gpuTFlops: 40,
     });
-    it('should recommend GTX 1080 Ti for medium-low memory and flops', () => {
-      expect(recommendGPU(9, 1.5 * 1e9)).toBe('Minimum recommendation: NVIDIA GTX 1080 Ti');
-      expect(recommendGPU(11, 2 * 1e9)).toBe('Minimum recommendation: NVIDIA GTX 1080 Ti');
+
+    expect(throughput.tokensPerSecond).toBeGreaterThan(0);
+    expect(throughput.millisecondsPerToken).toBeGreaterThan(0);
+  });
+
+  it('estimates cloud cost', () => {
+    const cost = estimateCloudCost({ hourlyRate: 3.06, durationHours: 2 });
+    expect(cost.totalCost).toBeCloseTo(6.12);
+  });
+
+  it('recommends GPUs with enough memory headroom', () => {
+    const results = recommendGpus(10, 5);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((gpu) => gpu.memoryHeadroomGB >= 0)).toBe(true);
+  });
+
+  it('estimates decoder flops', () => {
+    const flops = estimateDecoderFlops({
+      numLayers: 32,
+      hiddenSize: 4096,
+      sequenceLength: 2048,
+      vocabSize: 32000,
     });
-    it('should recommend RTX 2080 Ti for medium-high memory and flops', () => {
-      expect(recommendGPU(12, 2.1 * 1e9)).toBe('Minimum recommendation: NVIDIA RTX 2080 Ti');
-      expect(recommendGPU(24, 5 * 1e9)).toBe('Minimum recommendation: NVIDIA RTX 2080 Ti');
+    expect(flops).toBeGreaterThan(0);
+  });
+
+  it('estimates transformer parameters when not explicitly provided', () => {
+    const params = estimateTransformerParameters({
+      vocabSize: 32000,
+      hiddenSize: 4096,
+      numLayers: 32,
+      numAttentionHeads: 32,
     });
-    it('should recommend A100 or higher for high memory or flops', () => {
-      expect(recommendGPU(25, 5 * 1e9)).toBe('Minimum recommendation: NVIDIA A100 or higher');
-      expect(recommendGPU(24, 5.1 * 1e9)).toBe('Minimum recommendation: NVIDIA A100 or higher');
-    });
+
+    expect(params).toBeGreaterThan(0);
+  });
+
+  it('derives a llama-style architecture from parameter counts', () => {
+    const sevenB = estimateLlamaStyleArchitecture(7 * 10 ** 9);
+    expect(sevenB.hiddenSize).toBeGreaterThan(3000);
+    expect(sevenB.numLayers).toBeGreaterThan(20);
+
+    const seventyB = estimateLlamaStyleArchitecture(70 * 10 ** 9);
+    expect(seventyB.hiddenSize).toBeGreaterThan(sevenB.hiddenSize);
+    expect(seventyB.numLayers).toBeGreaterThan(sevenB.numLayers);
+  });
+
+  it('estimates memory from billions helper', () => {
+    const gb = calculateMemoryFromBillions(7, 16);
+    expect(gb).toBeCloseTo(calculateWeightMemoryGB(7 * 10 ** 9, 16));
   });
 });
+

--- a/src/estimator/cloud-instances.json
+++ b/src/estimator/cloud-instances.json
@@ -1,0 +1,66 @@
+[
+  {
+    "provider": "AWS",
+    "name": "g5.xlarge",
+    "gpu": "NVIDIA A10G",
+    "gpus": 1,
+    "vram_per_gpu_gb": 24,
+    "hourly_rate": 1.006
+  },
+  {
+    "provider": "AWS",
+    "name": "p3.2xlarge",
+    "gpu": "NVIDIA V100",
+    "gpus": 1,
+    "vram_per_gpu_gb": 16,
+    "hourly_rate": 3.06
+  },
+  {
+    "provider": "AWS",
+    "name": "p4d.24xlarge",
+    "gpu": "NVIDIA A100",
+    "gpus": 8,
+    "vram_per_gpu_gb": 40,
+    "hourly_rate": 24.15
+  },
+  {
+    "provider": "GCP",
+    "name": "a2-highgpu-1g",
+    "gpu": "NVIDIA A100",
+    "gpus": 1,
+    "vram_per_gpu_gb": 40,
+    "hourly_rate": 2.95
+  },
+  {
+    "provider": "GCP",
+    "name": "g2-standard-4",
+    "gpu": "NVIDIA L4",
+    "gpus": 1,
+    "vram_per_gpu_gb": 24,
+    "hourly_rate": 0.99
+  },
+  {
+    "provider": "Azure",
+    "name": "Standard_NC8as_T4_v3",
+    "gpu": "NVIDIA T4",
+    "gpus": 1,
+    "vram_per_gpu_gb": 16,
+    "hourly_rate": 0.9
+  },
+  {
+    "provider": "Azure",
+    "name": "Standard_ND40rs_v2",
+    "gpu": "NVIDIA V100",
+    "gpus": 8,
+    "vram_per_gpu_gb": 32,
+    "hourly_rate": 28.36
+  },
+  {
+    "provider": "Lambda",
+    "name": "Lambda Cloud A100",
+    "gpu": "NVIDIA A100",
+    "gpus": 1,
+    "vram_per_gpu_gb": 80,
+    "hourly_rate": 1.99
+  }
+]

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,755 +1,1045 @@
 import axios from 'axios';
-import * as React from 'react';
-import { useState } from 'react';
+import Head from 'next/head';
+import { useCallback, useMemo, useState } from 'react';
 
 import Seo from '@/components/Seo';
 
+import cloudInstances from '@/estimator/cloud-instances.json';
 import {
-  calculateFlops,
-  calculateMemory,
-  estimateInferenceTime,
-  estimateTrainingCost,
-  estimateModelSize,
-  estimateModelSizeT5,
-  recommendGPU,
+  estimateCloudCost,
+  estimateDecoderFlops,
+  estimateLlamaStyleArchitecture,
+  estimateMemory,
+  estimateThroughput,
+  estimateTransformerParameters,
+  ExecutionMode,
+  MemoryBreakdown,
+  PrecisionBits,
+  recommendGpus,
 } from '@/estimator/estimator';
 import gpus from '@/estimator/gpus.json';
-/**
- * SVGR Support
- * Caveat: No React Props Type.
- *
- * You can override the next-env if the type is important to you
- * @see https://stackoverflow.com/questions/68103844/how-to-override-next-js-svg-module-declaration
- */
+
+type CloudInstance = (typeof cloudInstances)[number];
+type Gpu = (typeof gpus)[number];
+
+interface ModelMetadata {
+  parameterCount: number;
+  hiddenSize: number;
+  numLayers: number;
+  numHeads: number;
+  intermediateSize?: number;
+  sequenceLength?: number;
+  vocabSize?: number;
+  dtypeBits?: PrecisionBits;
+}
+
+const DEFAULT_MODEL_ID = 'meta-llama/Llama-2-7b-hf';
+
+const bitsOptions: PrecisionBits[] = [32, 16, 8, 4];
+
+function safeNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  return undefined;
+}
+
+function formatNumber(value: number, fractionDigits = 2): string {
+  if (!Number.isFinite(value)) return 'N/A';
+  if (Math.abs(value) >= 1000) {
+    return value.toLocaleString(undefined, {
+      maximumFractionDigits: fractionDigits,
+      minimumFractionDigits: 0,
+    });
+  }
+  return value.toFixed(fractionDigits);
+}
+
+function formatMemory(value: number): string {
+  if (value <= 0) return '0 GB';
+  return `${formatNumber(value)} GB`;
+}
 
 export default function HomePage() {
-  const [modelId, setModelId] = useState<string>('google/flan-t5-xl');
-  const [modelError, setModelError] = useState<boolean>(false);
-  // Estiamting the number of parameters
-  const [numParams, setNumParams] = useState<number>(0);
-  const [bytes, setBytes] = useState<number>(32);
-  //Estimating the number of flops
-  const [numLayers, setNumLayers] = useState<number>(0);
-  const [hiddenSize, setHiddenSize] = useState<number>(0);
-  const [numHeads, setNumHeads] = useState<number>(0); // numHeads is kept for other potential uses or if UI still has it
-  const [vocabSize, setVocabSize] = useState<number>(0);
-  const [seqLength, setSeqLength] = useState<number>(512); // Added seqLength state
-  // const [head_kv, setHead_kv] = useState<number>(0);
+  const [modelId, setModelId] = useState<string>(DEFAULT_MODEL_ID);
+  const [parameterBillions, setParameterBillions] = useState<number>(7);
+  const [sequenceLength, setSequenceLength] = useState<number>(4096);
+  const [vocabSize, setVocabSize] = useState<number>(32000);
+  const [mode, setMode] = useState<ExecutionMode>('inference');
+  const [weightBits, setWeightBits] = useState<PrecisionBits>(16);
+  const [kvBits, setKvBits] = useState<PrecisionBits>(16);
+  const [overheadFactor, setOverheadFactor] = useState<number>(1.15);
+  const [optimizer, setOptimizer] = useState<
+    'adamw' | 'adam' | 'adafactor' | 'lamb' | 'none'
+  >('adamw');
+  const [efficiency, setEfficiency] = useState<number>(0.3);
+  const [concurrentUsers, setConcurrentUsers] = useState<number>(1);
+  const [trainingBatchSize, setTrainingBatchSize] = useState<number>(32);
+  const [architectureMode, setArchitectureMode] = useState<'auto' | 'manual'>(
+    'auto'
+  );
+  const [manualHiddenSize, setManualHiddenSize] = useState<number>(4096);
+  const [manualNumLayers, setManualNumLayers] = useState<number>(32);
+  const [manualNumHeads, setManualNumHeads] = useState<number>(32);
+  const [manualIntermediateSize, setManualIntermediateSize] =
+    useState<number>(0);
+  const [selectedGpuName, setSelectedGpuName] = useState<Gpu['name']>(
+    gpus[0].name
+  );
+  const [selectedInstanceName, setSelectedInstanceName] = useState<
+    CloudInstance['name']
+  >(cloudInstances[0].name);
+  const [runtimeHours, setRuntimeHours] = useState<number>(1);
+  const [customHourlyRate, setCustomHourlyRate] = useState<number | ''>('');
+  const [modelError, setModelError] = useState<string | null>(null);
+  const [isLoadingModel, setIsLoadingModel] = useState<boolean>(false);
 
-  //Estimating the inference time
-  const [calculatedGFlops, setCalculatedGFlops] = useState<number>(0); // For FLOPs estimator output
-  const [selectedGpuName, setSelectedGpuName] = useState<string>(gpus[0].name);
-  const [gpuTFlops, setGpuTFlops] = useState<number>(gpus[0].fp32_tflops);
-  const [memoryBandwidth, setMemoryBandwidth] = useState<number>(gpus[0].memory_bandwidth_gb_s); // Corrected typo setMemoryBaandwith
-  const [overheadFactor, setOverheadFactor] = useState<number>(1.2);
-  // numParams for inference estimator is taken from the general numParams state
+  const parameterCount = useMemo(
+    () => Math.max(parameterBillions, 0) * 10 ** 9,
+    [parameterBillions]
+  );
 
-  //Estimating cloud training cost
-  const [selectedTrainingGpuName, setSelectedTrainingGpuName] = useState<string>(gpus[0].name);
-  const [trainingGpuTFlops, setTrainingGpuTFlops] = useState<number>(gpus[0].fp32_tflops);
-  const [trainingMemoryBandwidth, setTrainingMemoryBandwidth] = useState<number>(gpus[0].memory_bandwidth_gb_s);
-  const [gpuHourlyCost, setGpuHourlyCost] = useState<number>(0);
-  const [numEpochs, setNumEpochs] = useState<number>(0);
-  const [datasetSize, setDatasetSize] = useState<number>(0);
-  const [recommendedGpuMessage, setRecommendedGpuMessage] = useState<string>('');
+  const autoArchitecture = useMemo(
+    () => estimateLlamaStyleArchitecture(parameterCount),
+    [parameterCount]
+  );
 
-  React.useEffect(() => {
-    const memoryInGB = calculateMemory(numParams * 10 ** 9, bytes);
-    const flopsForRecommendation = calculatedGFlops * 10 ** 9; // Convert GFLOPs to FLOPs
-    if (numParams > 0 && bytes > 0 && calculatedGFlops > 0) { // ensure valid inputs before recommending
-      setRecommendedGpuMessage(recommendGPU(memoryInGB, flopsForRecommendation));
-    } else {
-      setRecommendedGpuMessage('Please provide model parameters and FLOPs for a recommendation.');
+  const enableManualOverrides = useCallback(() => {
+    if (architectureMode === 'manual') return;
+    if (autoArchitecture.hiddenSize) {
+      setManualHiddenSize(autoArchitecture.hiddenSize);
     }
-  }, [numParams, bytes, calculatedGFlops]);
-
-  const formatInferenceTime = (seconds: number): string => {
-    if (seconds < 0.001 && seconds > 0) {
-      return `${(seconds * 1000).toFixed(2)} ms`;
-    } else if (seconds < 1) {
-      return `${seconds.toFixed(4)} s`;
-    } else if (seconds < 60) {
-      return `${seconds.toFixed(2)} s`;
-    } else {
-      return `${(seconds / 60).toFixed(2)} min`;
+    if (autoArchitecture.numLayers) {
+      setManualNumLayers(autoArchitecture.numLayers);
     }
-  };
-
-  const formatGB = (num: number): string => {
-    if (num === undefined || num <= 0) { // Changed condition to handle undefined or zero/negative
-      return 'N/A'; // Or some other placeholder
+    if (autoArchitecture.numHeads) {
+      setManualNumHeads(autoArchitecture.numHeads);
     }
-    if (num < 1) { // Kept this for small values that are positive
-      return '<1';
-    } else {
-      return num.toFixed(2).toString();
+    if (autoArchitecture.intermediateSize) {
+      setManualIntermediateSize(autoArchitecture.intermediateSize);
     }
-  };
+    setArchitectureMode('manual');
+  }, [
+    architectureMode,
+    autoArchitecture.hiddenSize,
+    autoArchitecture.intermediateSize,
+    autoArchitecture.numHeads,
+    autoArchitecture.numLayers,
+  ]);
 
-  const setModel = async (modelId: string) => {
-    if (modelId.length > 0) {
-      try {
-        const res = await axios.get(
-          `https://huggingface.co/${modelId}/raw/main/config.json`
-        );
-        const model = res.data;
-        // console.log(model);
-        if (model) {
-          setModelError(false); // Reset error state at the beginning
+  const enableAutoArchitecture = useCallback(() => {
+    setArchitectureMode('auto');
+  }, []);
 
-          // Extract num_params
-          let paramsExtracted = false;
-          const paramKeys = [
-            'num_parameters', 'n_params', 'num_params', 'model_params',
-            'total_params', 'N', 'n_parameters' // Added n_parameters as another common one
-          ];
+  const effectiveHiddenSize = useMemo(() => {
+    const autoValue = autoArchitecture.hiddenSize || manualHiddenSize;
+    return architectureMode === 'auto' ? autoValue : manualHiddenSize || autoValue;
+  }, [architectureMode, autoArchitecture.hiddenSize, manualHiddenSize]);
 
-          for (const key of paramKeys) {
-            if (model[key] !== undefined && typeof model[key] === 'number') {
-              let val = model[key];
-              if (val === 0) { // Explicitly handle 0 if found directly
-                setNumParams(0);
-                paramsExtracted = true;
-                break;
-              }
-              // Heuristic: if value is very large, assume raw count. If small, assume billions.
-              if (val > 1000000) { // If > 1M, assume it's a raw count
-                setNumParams(val / 10 ** 9);
-                paramsExtracted = true;
-                break;
-              } else if (val > 0 && val < 1000) { // If > 0 and < 1k, assume it's already in billions
-                setNumParams(val);
-                paramsExtracted = true;
-                break;
-              }
-              // If val is between 1000 and 1000000, it's ambiguous without more context.
-              // For now, we'll only use it if it's clearly raw or clearly billions.
-              // Or, we can decide to treat moderately sized numbers as raw counts too.
-              // Let's refine: if a key is found, and it's not 0, assume it's the count.
-              // The heuristic for "already in billions" vs "raw" is tricky.
-              // For now, let's assume any of these direct keys, if non-zero, are raw counts.
-              // The user can manually adjust if the scale is misinterpreted.
-              // Re-evaluating the heuristic:
-              // If a direct key like 'num_parameters' is found, it's most likely the full raw count.
-              // Division by 10**9 will handle it. If it was accidentally in billions, it becomes very small.
-              // The original code just did `params / 10**9` if `model.num_params` was found.
-              // Let's stick to: if a direct key is found, assume it's the raw count.
-            }
-          }
+  const effectiveNumLayers = useMemo(() => {
+    const autoValue = autoArchitecture.numLayers || manualNumLayers;
+    return architectureMode === 'auto' ? autoValue : manualNumLayers || autoValue;
+  }, [architectureMode, autoArchitecture.numLayers, manualNumLayers]);
 
-          // If params were not extracted from direct keys, then try calculation
-          if (!paramsExtracted) {
-            // Try to get num_params from a few common places first, assuming raw count
-            let rawParams: number | undefined = undefined;
-            const directRawParamKeys = ['num_parameters', 'n_params', 'num_params', 'total_params', 'N', 'n_parameters', 'model.num_parameters']; // model.num_parameters might be nested
+  const effectiveNumHeads = useMemo(() => {
+    const fallback = Math.max(1, Math.round((effectiveHiddenSize || 1) / 128));
+    if (architectureMode === 'auto') {
+      return autoArchitecture.numHeads || fallback;
+    }
+    return manualNumHeads || autoArchitecture.numHeads || fallback;
+  }, [
+    architectureMode,
+    autoArchitecture.numHeads,
+    effectiveHiddenSize,
+    manualNumHeads,
+  ]);
 
-            for (const key of directRawParamKeys) {
-                let valToCheck = model[key];
-                if (key === 'model.num_parameters' && model.model && typeof model.model.num_parameters === 'number') { // Check nested common pattern
-                    valToCheck = model.model.num_parameters;
-                }
+  const effectiveIntermediateSize = useMemo(() => {
+    const autoValue =
+      autoArchitecture.intermediateSize || manualIntermediateSize || 0;
+    if (architectureMode === 'auto') {
+      return autoValue;
+    }
+    if (manualIntermediateSize && manualIntermediateSize > 0) {
+      return manualIntermediateSize;
+    }
+    return manualHiddenSize > 0 ? manualHiddenSize * 4 : autoValue;
+  }, [
+    architectureMode,
+    autoArchitecture.intermediateSize,
+    manualHiddenSize,
+    manualIntermediateSize,
+  ]);
 
-                if (typeof valToCheck === 'number' && valToCheck > 0) {
-                    // Heuristic: if value > 1M, it's raw count. If < 1000, it's billions.
-                    // To simplify and be consistent with calculations: always assume direct keys are raw full counts.
-                    // If a config provides 'num_params: 7', it means 7 params, not 7B.
-                    // The UI input is in Billions, so it's better to be consistent.
-                    // Calculations from estimateModelSize are raw, then divided.
-                    // So, if we find a direct key, assume it's raw and divide.
-                    rawParams = valToCheck;
-                    setNumParams(rawParams / 10 ** 9);
-                    paramsExtracted = true;
-                    break;
-                }
-            }
+  const effectiveBatchSize = useMemo(() => {
+    if (mode === 'inference') {
+      return Math.max(1, concurrentUsers);
+    }
+    return Math.max(1, trainingBatchSize);
+  }, [concurrentUsers, mode, trainingBatchSize]);
 
-            if (!paramsExtracted) {
-              // Fallback to calculation
-              if (model.architectures?.includes('T5ForConditionalGeneration')) {
-                // Ensure all necessary T5 config fields are present
-              if (model.d_model && model.vocab_size && model.num_layers && model.num_decoder_layers && model.d_ff && model.n_positions) {
-                params = estimateModelSizeT5({
-                  d_model: model.d_model,
-                  vocab_size: model.vocab_size,
-                  n_head: model.num_heads || model.n_head, // Handle variations
-                  num_layers: model.num_layers,
-                  n_head_kv: model.num_heads_kv || model.n_head_kv || model.num_attention_heads, // Handle variations
-                  d_ff: model.d_ff,
-                  n_positions: model.n_positions,
-                  num_decoder_layers: model.num_decoder_layers,
-                });
-                setNumParams(params / 10 ** 9);
-              } else {
-                console.error('Missing parameters for T5 model size estimation');
-                setModelError(true);
-              }
-            } else {
-              // Use generic estimator for other architectures
-              // Ensure all necessary generic config fields are present
-              const hiddenSizeVal = model.hidden_size || model.d_model;
-              const numLayersVal = model.num_layers || model.n_layer || model.num_hidden_layers;
-              const numHeadsVal = model.num_heads || model.n_head || model.num_attention_heads;
-              const vocabSizeVal = model.vocab_size;
-              // n_head_kv might not always be present, provide a default or handle absence
-              const numHeadsKvVal = model.n_head_kv || model.num_key_value_heads;
+  const selectedGpu = useMemo(() => {
+    return gpus.find((gpu) => gpu.name === selectedGpuName) ?? gpus[0];
+  }, [selectedGpuName]);
 
+  const selectedInstance = useMemo(() => {
+    return (
+      cloudInstances.find((instance) => instance.name === selectedInstanceName) ??
+      cloudInstances[0]
+    );
+  }, [selectedInstanceName]);
 
-              if (hiddenSizeVal && numLayersVal && numHeadsVal && vocabSizeVal) {
-                const estimatedRawParams = estimateModelSize(
-                  vocabSizeVal,
-                  hiddenSizeVal,
-                  numHeadsVal,
-                  numLayersVal,
-                  numHeadsKvVal
-                );
-                if (estimatedRawParams > 0) {
-                    setNumParams(estimatedRawParams / 10 ** 9);
-                    paramsExtracted = true;
-                } else {
-                    console.error('Generic model size estimation resulted in 0 or negative params.');
-                    setModelError(true);
-                }
-              } else {
-                console.error('Missing parameters for generic model size estimation from config:', model);
-                setModelError(true);
-              }
-            }
-          }
-        } // End of `if (!paramsExtracted)` after direct key search
+  const flops = useMemo(() => {
+    if (
+      !effectiveNumLayers ||
+      !effectiveHiddenSize ||
+      !sequenceLength ||
+      !vocabSize
+    ) {
+      return 0;
+    }
 
-          if (!paramsExtracted) { // If still not extracted after direct keys and calculations
-            console.error('Could not determine num_params from config or calculation.');
-            setModelError(true);
-            // Optionally set numParams to 0 or a specific error indicator if needed
-            setNumParams(0);
-          }
+    return estimateDecoderFlops({
+      numLayers: effectiveNumLayers,
+      hiddenSize: effectiveHiddenSize,
+      sequenceLength,
+      vocabSize,
+    });
+  }, [
+    effectiveHiddenSize,
+    effectiveNumLayers,
+    sequenceLength,
+    vocabSize,
+  ]);
 
-          // Extract other parameters with robust handling for different names
-          const numLayersValue = model.num_layers || model.n_layer || model.num_hidden_layers;
-          if (numLayersValue !== undefined) setNumLayers(numLayersValue);
-          else {
-            console.error('num_layers not found in config');
-            setModelError(true);
-          }
+  const memoryBreakdown: MemoryBreakdown = useMemo(() => {
+    if (!parameterCount || !effectiveHiddenSize || !effectiveNumLayers) {
+      return {
+        weightsGB: 0,
+        activationsGB: 0,
+        kvCacheGB: 0,
+        optimizerGB: 0,
+        baseTotalGB: 0,
+        overheadGB: 0,
+        totalGB: 0,
+      };
+    }
 
-          const hiddenSizeValue = model.hidden_size || model.d_model;
-          if (hiddenSizeValue !== undefined) setHiddenSize(hiddenSizeValue);
-          else {
-            console.error('hidden_size or d_model not found in config');
-            setModelError(true);
-          }
+    return estimateMemory({
+      parameterCount,
+      weightPrecisionBits: weightBits,
+      mode,
+      hiddenSize: effectiveHiddenSize,
+      numLayers: effectiveNumLayers,
+      sequenceLength,
+      batchSize: effectiveBatchSize,
+      kvCachePrecisionBits: kvBits,
+      optimizer: mode === 'training' ? optimizer : 'none',
+      overheadFactor,
+    });
+  }, [
+    parameterCount,
+    weightBits,
+    mode,
+    effectiveHiddenSize,
+    effectiveNumLayers,
+      sequenceLength,
+    effectiveBatchSize,
+    kvBits,
+    optimizer,
+    overheadFactor,
+  ]);
 
-          const numHeadsValue = model.num_attention_heads || model.num_heads || model.n_head;
-          if (numHeadsValue !== undefined) setNumHeads(numHeadsValue);
-          else {
-            console.error('num_heads not found in config');
-            setModelError(true);
-          }
+  const throughput = useMemo(() => {
+    if (!parameterCount) {
+      return { tokensPerSecond: 0, millisecondsPerToken: 0 };
+    }
 
-          if (model.vocab_size !== undefined) setVocabSize(model.vocab_size);
-          else {
-            console.error('vocab_size not found in config');
-            setModelError(true);
-          }
+    return estimateThroughput({
+      parameterCount,
+      gpuTFlops: selectedGpu?.fp32_tflops ?? 0,
+      efficiency,
+    });
+  }, [parameterCount, selectedGpu, efficiency]);
 
-          if (model.torch_dtype) {
-            const dtype = model.torch_dtype;
-            if (dtype === 'float32' || dtype === 'torch.float32') setBytes(32);
-            else if (dtype === 'float16' || dtype === 'torch.float16') setBytes(16);
-            else if (dtype === 'bfloat16' || dtype === 'torch.bfloat16') setBytes(16); // bfloat16 is also 2 bytes
-            else if (dtype === 'int8') setBytes(8);
-            else {
-              console.warn(`Unsupported torch_dtype: ${dtype}, defaulting to 32 bits`);
-              setBytes(32); // Default or handle as an error
-            }
-          } else {
-            console.warn('torch_dtype not found in config, defaulting to 32 bits');
-            setBytes(32); // Default if not specified
-          }
+  const hourlyRate = useMemo(() => {
+    if (typeof customHourlyRate === 'number' && customHourlyRate > 0) {
+      return customHourlyRate;
+    }
+    return selectedInstance.hourly_rate;
+  }, [customHourlyRate, selectedInstance.hourly_rate]);
 
-        } else {
-          //This case should ideally not be reached if axios throws an error for non-200 responses
-          setModelError(true);
-        }
-      } catch (e) {
-        console.error('Failed to fetch or process model config:', e);
-        setModelError(true);
+  const costEstimate = useMemo(() => {
+    if (!runtimeHours || runtimeHours <= 0) {
+      return { totalCost: 0, hourlyRate, durationHours: runtimeHours };
+    }
+
+    return estimateCloudCost({
+      hourlyRate,
+      durationHours: runtimeHours,
+    });
+  }, [hourlyRate, runtimeHours]);
+
+  const recommendedGpuList = useMemo(() => {
+    if (!memoryBreakdown.totalGB) return [];
+    return recommendGpus(memoryBreakdown.totalGB, 5);
+  }, [memoryBreakdown.totalGB]);
+
+  const applyModelMetadata = useCallback((metadata: ModelMetadata) => {
+    if (metadata.parameterCount && metadata.parameterCount > 0) {
+      setParameterBillions(metadata.parameterCount / 10 ** 9);
+    }
+
+    const hasArchitecture = Boolean(
+      (metadata.hiddenSize && metadata.hiddenSize > 0) ||
+        (metadata.numLayers && metadata.numLayers > 0) ||
+        (metadata.numHeads && metadata.numHeads > 0) ||
+        (metadata.intermediateSize && metadata.intermediateSize > 0)
+    );
+
+    if (hasArchitecture) {
+      setArchitectureMode('manual');
+    }
+
+    if (metadata.hiddenSize && metadata.hiddenSize > 0) {
+      setManualHiddenSize(metadata.hiddenSize);
+    }
+    if (metadata.numLayers && metadata.numLayers > 0) {
+      setManualNumLayers(metadata.numLayers);
+    }
+    if (metadata.numHeads && metadata.numHeads > 0) {
+      setManualNumHeads(metadata.numHeads);
+    }
+    if (metadata.intermediateSize && metadata.intermediateSize > 0) {
+      setManualIntermediateSize(metadata.intermediateSize);
+    }
+    if (metadata.sequenceLength && metadata.sequenceLength > 0) {
+      setSequenceLength(metadata.sequenceLength);
+    }
+    if (metadata.vocabSize && metadata.vocabSize > 0) {
+      setVocabSize(metadata.vocabSize);
+    }
+    if (metadata.dtypeBits) setWeightBits(metadata.dtypeBits);
+  }, []);
+
+  const fetchModelConfig = useCallback(
+    async (id: string) => {
+      const trimmedId = id.trim();
+      if (!trimmedId) {
+        setModelError('Please enter a Hugging Face model ID.');
+        return;
       }
-    } else {
-      // Handle empty modelId input if necessary, though the button might be disabled
-      setModelError(true);
-    }
-  };
+
+      setIsLoadingModel(true);
+      setModelError(null);
+      try {
+        const response = await axios.get(
+          `https://huggingface.co/${trimmedId}/raw/main/config.json`,
+          {
+            timeout: 10000,
+          }
+        );
+        const metadata = parseModelConfig(response.data);
+        applyModelMetadata(metadata);
+      } catch (error: unknown) {
+        setModelError(
+          'Unable to retrieve model configuration from Hugging Face.'
+        );
+        if (process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
+          console.error(error);
+        }
+      } finally {
+        setIsLoadingModel(false);
+      }
+    },
+    [applyModelMetadata]
+  );
+
+  const memoryHeadroom = useMemo(() => {
+    if (!selectedGpu) return null;
+    return selectedGpu.memory_gb - memoryBreakdown.totalGB;
+  }, [selectedGpu, memoryBreakdown.totalGB]);
 
   return (
-    <main data-theme='dark' className='bg-full'>
+    <main data-theme='dark' className='min-h-screen bg-base-200 text-base-content'>
       <Seo />
-      <h1 className='mh-auto text-primary mt-5 text-center'>
-        AI Project Prophet
-      </h1>
-      <p className='text-center'>
-        Estimate Hardware and Costs of running LLMs and Transformer projects
-      </p>
-      <hr className='mx-auto my-6 w-3/4 border-2 border-black' />
-
-      <div className='m-auto max-w-xs rounded-lg border-2 border-black p-5'>
-        <label className='label'>
-          <span className='label-text'>Huggingface Model ID</span>
-        </label>
-        <input
-          className={
-            modelError
-              ? 'input input-bordered input-error w-full max-w-xs'
-              : 'input input-bordered input-primary w-full max-w-xs'
-          }
-          placeholder='e.g. bert-base-uncased'
-          type='text'
-          onChange={(e) => {
-            setModelId(e.target.value);
-          }}
-          value={modelId}
-        />
-        <button
-          className='btn btn-primary mt-2 w-full'
-          onClick={() => setModel(modelId)}
-        >
-          Fetch Model Details
-        </button>
-      </div>
-      <div className='grid md:grid-cols-2'>
-        <div className='m-5 rounded-lg border-2 border-black p-5'>
-          <h2>Memory Estimator</h2>
-          <p>
-            Estimate the amount of GPU memory required to load a models weights
+      <Head>
+        <title>LLM Cost &amp; Resource Estimator</title>
+      </Head>
+      <div className='mx-auto max-w-6xl px-4 py-10'>
+        <header className='space-y-4 text-center'>
+          <h1 className='text-3xl font-bold text-primary'>
+            LLM Resource Usage &amp; Cost Calculator
+          </h1>
+          <p className='text-base-content/80'>
+            Analyse memory requirements, throughput and cloud spend for open-source language models in seconds.
           </p>
-          <div className='md:flex md:justify-evenly md:space-x-4'>
-            <div className='form-control w-full max-w-xs mb-4 md:mb-0'>
-              <label className='label'>
-                <span className='label-text'>Parameter Size</span>
-                <span className='label-text-alt mr-1'> (billions)</span>
-                <span className='tooltip tooltip-right' data-tip="Total number of parameters in the model, in billions. E.g., for a 7B model, enter 7. This is typically fetched from the model's configuration.">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
+        </header>
+
+        <section className='mt-10 rounded-xl border border-base-300 bg-base-100 p-6 shadow-lg'>
+          <div className='flex flex-col gap-4 md:flex-row md:items-end'>
+            <label className='flex-1'>
+              <span className='label-text font-semibold'>Hugging Face model ID</span>
               <input
-                className='input input-bordered input-primary w-full'
-                placeholder='Number of Model Parameters'
-                type='number'
-                onChange={(e) => {
-                  setNumParams(parseFloat(e.target.value) || 0);
-                }}
-                value={numParams}
+                className='input input-bordered mt-2 w-full'
+                placeholder='meta-llama/Llama-2-7b-hf'
+                value={modelId}
+                onChange={(event) => setModelId(event.target.value)}
+                aria-label='Hugging Face model identifier'
               />
+            </label>
+            <button
+              className='btn btn-primary w-full md:w-auto'
+              onClick={() => fetchModelConfig(modelId)}
+              disabled={isLoadingModel}
+            >
+              {isLoadingModel ? 'Loading…' : 'Fetch configuration'}
+            </button>
+          </div>
+          {modelError && (
+            <p className='mt-3 rounded-lg bg-error/10 px-4 py-2 text-sm text-error'>
+              {modelError}
+            </p>
+          )}
+
+          <dl className='mt-6 grid gap-4 text-sm md:grid-cols-3'>
+            <div>
+              <dt className='font-semibold text-base-content/70'>Parameters</dt>
+              <dd className='text-lg font-bold'>
+                {formatNumber(parameterBillions, 3)} B
+              </dd>
             </div>
-            <div className='form-control w-full max-w-xs'>
-              <label className='label'>
-                <span className='label-text'>Float Size</span>
-                <span className='label-text-alt'>Bits</span>
-                <span className='tooltip tooltip-right' data-tip="Precision of model weights. Common values are 32 (FP32), 16 (FP16/BF16), 8 (INT8), 4 (NF4).">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
-              <select
-                onChange={(e) => {
-                  setBytes(parseInt(e.target.value));
-                }}
-                className='select select-bordered w-full'
-                value={bytes}
-              >
-                <option value={32}>32-bit Float</option>
-                <option value={16}>16-bit Float</option>
-                <option value={8}>8-Bit Float</option>
-                <option value={4}>4-Bit Float</option>
-              </select>
+            <div>
+              <dt className='font-semibold text-base-content/70'>Hidden size</dt>
+              <dd className='text-lg font-bold'>{effectiveHiddenSize || '–'}</dd>
+            </div>
+            <div>
+              <dt className='font-semibold text-base-content/70'>Layers</dt>
+              <dd className='text-lg font-bold'>{effectiveNumLayers || '–'}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className='mt-10 grid gap-8 lg:grid-cols-[1.15fr_0.85fr]'>
+          <div className='space-y-6'>
+            <div className='rounded-xl border border-base-300 bg-base-100 p-6 shadow-lg'>
+              <div className='flex flex-col gap-3 md:flex-row md:items-start md:justify-between'>
+                <div>
+                  <h2 className='text-xl font-semibold'>Quick estimator</h2>
+                  <p className='mt-1 text-sm text-base-content/70'>
+                    Size weights and KV cache instantly from core workload inputs.
+                  </p>
+                </div>
+                <div className='join self-start'>
+                  <button
+                    className={`btn btn-sm join-item ${
+                      mode === 'inference' ? 'btn-primary' : 'btn-ghost'
+                    }`}
+                    type='button'
+                    onClick={() => setMode('inference')}
+                  >
+                    Inference
+                  </button>
+                  <button
+                    className={`btn btn-sm join-item ${
+                      mode === 'training' ? 'btn-primary' : 'btn-ghost'
+                    }`}
+                    type='button'
+                    onClick={() => setMode('training')}
+                  >
+                    Training
+                  </button>
+                </div>
+              </div>
+
+              <div className='mt-6 grid gap-4 md:grid-cols-2'>
+                <label className='flex flex-col text-sm'>
+                  Parameter count (billions)
+                  <input
+                    className='input input-bordered mt-1'
+                    type='number'
+                    min='0'
+                    step='0.1'
+                    value={parameterBillions}
+                    onChange={(event) =>
+                      setParameterBillions(Number(event.target.value) || 0)
+                    }
+                  />
+                </label>
+                <label className='flex flex-col text-sm'>
+                  Context length (tokens)
+                  <input
+                    className='input input-bordered mt-1'
+                    type='number'
+                    min='1'
+                    value={sequenceLength}
+                    onChange={(event) =>
+                      setSequenceLength(Number(event.target.value) || 0)
+                    }
+                  />
+                </label>
+                <label className='flex flex-col text-sm'>
+                  Weight precision
+                  <select
+                    className='select select-bordered mt-1'
+                    value={weightBits}
+                    onChange={(event) =>
+                      setWeightBits(Number(event.target.value) as PrecisionBits)
+                    }
+                  >
+                    {bitsOptions.map((bits) => (
+                      <option key={bits} value={bits}>
+                        {bits}-bit
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className='flex flex-col text-sm'>
+                  KV cache precision
+                  <select
+                    className='select select-bordered mt-1'
+                    value={kvBits}
+                    onChange={(event) =>
+                      setKvBits(Number(event.target.value) as PrecisionBits)
+                    }
+                  >
+                    {bitsOptions.map((bits) => (
+                      <option key={bits} value={bits}>
+                        {bits}-bit
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className='flex flex-col text-sm'>
+                  Overhead factor
+                  <input
+                    className='input input-bordered mt-1'
+                    type='number'
+                    min='1'
+                    step='0.05'
+                    value={overheadFactor}
+                    onChange={(event) =>
+                      setOverheadFactor(Number(event.target.value) || 1)
+                    }
+                  />
+                </label>
+                {mode === 'training' && (
+                  <label className='flex flex-col text-sm'>
+                    Optimiser
+                    <select
+                      className='select select-bordered mt-1'
+                      value={optimizer}
+                      onChange={(event) =>
+                        setOptimizer(event.target.value as typeof optimizer)
+                      }
+                    >
+                      <option value='adamw'>AdamW</option>
+                      <option value='adam'>Adam</option>
+                      <option value='adafactor'>Adafactor</option>
+                      <option value='lamb'>LAMB</option>
+                      <option value='none'>None</option>
+                    </select>
+                  </label>
+                )}
+              </div>
+
+              {mode === 'inference' ? (
+                <div className='mt-6 space-y-2 text-sm'>
+                  <span className='font-semibold text-base-content/80'>
+                    Concurrent users
+                  </span>
+                  <div className='flex items-center gap-3'>
+                    <input
+                      className='range range-primary flex-1'
+                      type='range'
+                      min='1'
+                      max='64'
+                      step='1'
+                      value={concurrentUsers}
+                      onChange={(event) =>
+                        setConcurrentUsers(Number(event.target.value) || 1)
+                      }
+                    />
+                    <span className='badge badge-outline'>{concurrentUsers}</span>
+                  </div>
+                  <p className='text-xs text-base-content/70'>
+                    KV cache memory scales linearly with concurrent sequences
+                    and context length.
+                  </p>
+                </div>
+              ) : (
+                <label className='mt-6 flex flex-col text-sm'>
+                  Global batch size
+                  <input
+                    className='input input-bordered mt-1'
+                    type='number'
+                    min='1'
+                    value={trainingBatchSize}
+                    onChange={(event) =>
+                      setTrainingBatchSize(Number(event.target.value) || 1)
+                    }
+                  />
+                </label>
+              )}
+            </div>
+
+            <div className='rounded-xl border border-base-300 bg-base-100 p-6 shadow-lg'>
+              <div className='flex flex-col gap-3 md:flex-row md:items-start md:justify-between'>
+                <div>
+                  <h2 className='text-xl font-semibold'>Architecture assumptions</h2>
+                  <p className='mt-1 text-sm text-base-content/70'>
+                    {architectureMode === 'auto'
+                      ? 'Using LLaMA-style scaling heuristics derived from parameter count. Enable manual mode to match a specific checkpoint.'
+                      : 'Provide exact architecture values to refine KV cache and activation estimates.'}
+                  </p>
+                </div>
+                <div className='join self-start'>
+                  <button
+                    className={`btn btn-sm join-item ${
+                      architectureMode === 'auto' ? 'btn-primary' : 'btn-ghost'
+                    }`}
+                    type='button'
+                    onClick={enableAutoArchitecture}
+                  >
+                    Auto
+                  </button>
+                  <button
+                    className={`btn btn-sm join-item ${
+                      architectureMode === 'manual' ? 'btn-primary' : 'btn-ghost'
+                    }`}
+                    type='button'
+                    onClick={enableManualOverrides}
+                  >
+                    Manual
+                  </button>
+                </div>
+              </div>
+
+              <dl className='mt-6 grid gap-4 text-sm sm:grid-cols-2'>
+                <div>
+                  <dt className='font-semibold text-base-content/70'>Hidden size</dt>
+                  <dd className='text-lg font-semibold'>
+                    {effectiveHiddenSize || '–'}
+                  </dd>
+                </div>
+                <div>
+                  <dt className='font-semibold text-base-content/70'>Layers</dt>
+                  <dd className='text-lg font-semibold'>
+                    {effectiveNumLayers || '–'}
+                  </dd>
+                </div>
+                <div>
+                  <dt className='font-semibold text-base-content/70'>Attention heads</dt>
+                  <dd className='text-lg font-semibold'>
+                    {effectiveNumHeads || '–'}
+                  </dd>
+                </div>
+                <div>
+                  <dt className='font-semibold text-base-content/70'>Feed-forward size</dt>
+                  <dd className='text-lg font-semibold'>
+                    {effectiveIntermediateSize || '–'}
+                  </dd>
+                </div>
+              </dl>
+
+              {architectureMode === 'manual' && (
+                <div className='mt-6 space-y-4'>
+                  <div className='grid gap-4 md:grid-cols-2'>
+                    <label className='flex flex-col text-sm'>
+                      Hidden size
+                      <input
+                        className='input input-bordered mt-1'
+                        type='number'
+                        min='0'
+                        value={manualHiddenSize}
+                        onChange={(event) =>
+                          setManualHiddenSize(Number(event.target.value) || 0)
+                        }
+                      />
+                    </label>
+                    <label className='flex flex-col text-sm'>
+                      Layers
+                      <input
+                        className='input input-bordered mt-1'
+                        type='number'
+                        min='0'
+                        value={manualNumLayers}
+                        onChange={(event) =>
+                          setManualNumLayers(Number(event.target.value) || 0)
+                        }
+                      />
+                    </label>
+                    <label className='flex flex-col text-sm'>
+                      Attention heads
+                      <input
+                        className='input input-bordered mt-1'
+                        type='number'
+                        min='0'
+                        value={manualNumHeads}
+                        onChange={(event) =>
+                          setManualNumHeads(Number(event.target.value) || 0)
+                        }
+                      />
+                    </label>
+                    <label className='flex flex-col text-sm'>
+                      Feed-forward size
+                      <input
+                        className='input input-bordered mt-1'
+                        type='number'
+                        min='0'
+                        placeholder={
+                          manualHiddenSize ? String(manualHiddenSize * 4) : ''
+                        }
+                        value={manualIntermediateSize || ''}
+                        onChange={(event) =>
+                          setManualIntermediateSize(
+                            Number(event.target.value) || 0
+                          )
+                        }
+                      />
+                    </label>
+                  </div>
+                  <label className='flex flex-col text-sm'>
+                    Vocabulary size (for FLOPs)
+                    <input
+                      className='input input-bordered mt-1'
+                      type='number'
+                      min='0'
+                      value={vocabSize}
+                      onChange={(event) =>
+                        setVocabSize(Number(event.target.value) || 0)
+                      }
+                    />
+                  </label>
+                </div>
+              )}
+              {architectureMode === 'auto' && (
+                <p className='mt-5 rounded-lg bg-base-200 px-3 py-2 text-xs text-base-content/70'>
+                  Hidden size and depth follow public LLaMA scaling heuristics.
+                  Switch to manual mode to match custom architectures.
+                </p>
+              )}
             </div>
           </div>
-          <p>
-            Estimated memory:{' '}
-            <span className='font-bold text-lg'>{formatGB(calculateMemory(numParams * 10 ** 9, bytes))} GB</span>
-          </p>
-          <div className='mt-2'>
-            <p className='font-semibold'>GPU Recommendation: <span className='font-normal'>{recommendedGpuMessage}</span></p>
-          </div>
-        </div>
 
-        <div className='m-5 rounded-lg border-2 border-black p-5'>
-          <h2>FLOPs Estimator</h2>
-          <p className='mb-4'>Estimate the total FLOPs for a inference a transformer model.</p>
-          <div className='grid gap-4 md:grid-cols-2'>
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Layers</span>
-                <span className='tooltip tooltip-right' data-tip="Number of transformer layers in the model.">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full'
-                placeholder='Number of Layers'
-                type='number'
-                onChange={(e) => {
-                  setNumLayers(parseFloat(e.target.value) || 0);
-                }}
-                value={numLayers}
-              />
-            </div>
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Sequence Length</span>
-                <span className='tooltip tooltip-right' data-tip="The number of tokens in an input sequence for the model.">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full'
-                placeholder='Sequence Length'
-                type='number'
-                onChange={(e) => {
-                  setSeqLength(parseFloat(e.target.value) || 0);
-                }}
-                value={seqLength}
-              />
-            </div>
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Vocab Size</span>
-                <span className='tooltip tooltip-right' data-tip="The number of unique tokens in the model's vocabulary.">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full'
-                placeholder='Vocab Size'
-                type='number'
-                onChange={(e) => {
-                  setVocabSize(parseFloat(e.target.value) || 0);
-                }}
-                value={vocabSize}
-              />
-            </div>
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Hidden Layer Dimensions</span>
-                <span className='tooltip tooltip-right' data-tip="The dimensionality of the model's hidden states (d_model).">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full'
-                placeholder='Dimenonality of Hidden Layer'
-                type='number'
-                onChange={(e) => {
-                  setHiddenSize(parseFloat(e.target.value));
-                }}
-                value={hiddenSize}
-              />
-            </div>
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Attention Heads</span>
-                <span className='tooltip tooltip-right' data-tip="Number of attention heads in the model. (Currently not used in FLOPs calculation but kept for completeness).">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full'
-                placeholder='Number of Attention Heads'
-                type='number'
-                onChange={(e) => {
-                  setNumHeads(parseFloat(e.target.value) || 0);
-                }}
-                value={numHeads}
-              />
-            </div>
-          </div>
-          <p className='mt-4'>
-            Estimated Number of Floating Point Operations:{' '}
-            <span className='font-bold text-lg'>
-            {
-              (() => {
-                const currentFlops = calculateFlops(numLayers, seqLength, hiddenSize, vocabSize) / 10**9;
-                if (currentFlops !== calculatedGFlops && !isNaN(currentFlops)) {
-                  setTimeout(() => setCalculatedGFlops(currentFlops), 0);
-                }
-                return currentFlops.toFixed(2);
-              })()
-            }
-            </span>{' '}
-            GFLOPs{' '}
-          </p>
-        </div>
+          <div className='space-y-6'>
+            <div className='rounded-xl border border-base-300 bg-base-100 p-6 shadow-lg'>
+              <h2 className='text-xl font-semibold'>Memory &amp; hardware</h2>
+              <p className='mt-1 text-sm text-base-content/70'>
+                {mode === 'inference'
+                  ? `Assumes ${effectiveBatchSize} concurrent ${
+                      effectiveBatchSize === 1 ? 'user' : 'users'
+                    } at ${sequenceLength} tokens.`
+                  : `Assumes a global batch size of ${effectiveBatchSize} sequences.`}
+              </p>
+              <div className='mt-4 grid gap-3 text-sm'>
+                <div className='flex items-center justify-between'>
+                  <span>Model weights</span>
+                  <span className='font-semibold'>
+                    {formatMemory(memoryBreakdown.weightsGB)}
+                  </span>
+                </div>
+                <div className='flex items-center justify-between'>
+                  <span>Activations</span>
+                  <span className='font-semibold'>
+                    {formatMemory(memoryBreakdown.activationsGB)}
+                  </span>
+                </div>
+                <div className='flex items-center justify-between rounded-lg bg-primary/10 px-3 py-2'>
+                  <span className='flex items-center gap-2'>
+                    KV cache
+                    <span className='badge badge-outline badge-sm'>
+                      {kvBits}-bit
+                    </span>
+                  </span>
+                  <span className='font-semibold'>
+                    {formatMemory(memoryBreakdown.kvCacheGB)}
+                  </span>
+                </div>
+                {mode === 'training' && memoryBreakdown.optimizerGB > 0 && (
+                  <div className='flex items-center justify-between'>
+                    <span>Optimizer state</span>
+                    <span className='font-semibold'>
+                      {formatMemory(memoryBreakdown.optimizerGB)}
+                    </span>
+                  </div>
+                )}
+                <div className='flex items-center justify-between border-t border-base-300 pt-3'>
+                  <span>Total before overhead</span>
+                  <span className='font-semibold'>
+                    {formatMemory(memoryBreakdown.baseTotalGB)}
+                  </span>
+                </div>
+                <div className='flex items-center justify-between'>
+                  <span>Framework overhead ({formatNumber(overheadFactor, 2)}×)</span>
+                  <span className='font-semibold'>
+                    {formatMemory(memoryBreakdown.overheadGB)}
+                  </span>
+                </div>
+                <div className='flex items-center justify-between border-t border-base-300 pt-3 text-lg font-bold text-primary'>
+                  <span>Total VRAM needed</span>
+                  <span>{formatMemory(memoryBreakdown.totalGB)}</span>
+                </div>
+              </div>
 
-        <div className='m-5 rounded-lg border-2 border-black p-5'>
-          <h2>Inference Time Estimator</h2>
-          <p className='mb-4'>Estimate the time it takes to run inference on a model.</p>
-          <div className='flex flex-col space-y-4'> {/* Added space-y-4 */}
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Calculated GFLOPs (from above)</span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full bg-gray-100 dark:bg-gray-700' // Made read-only distinct
-                type='number'
-                value={calculatedGFlops.toFixed(2)}
-                readOnly
-              />
+              <div className='mt-6 rounded-lg bg-base-200 p-4'>
+                <label className='text-sm font-semibold text-base-content/80'>
+                  Compare against GPU
+                </label>
+                <select
+                  className='select select-bordered mt-2 w-full'
+                  value={selectedGpuName}
+                  onChange={(event) => setSelectedGpuName(event.target.value)}
+                >
+                  {gpus.map((gpu) => (
+                    <option key={gpu.name} value={gpu.name}>
+                      {gpu.name} ({gpu.memory_gb} GB)
+                    </option>
+                  ))}
+                </select>
+
+                {selectedGpu && (
+                  <p
+                    className={`mt-3 text-sm ${
+                      memoryHeadroom !== null && memoryHeadroom >= 0
+                        ? 'text-success'
+                        : 'text-error'
+                    }`}
+                  >
+                    {memoryHeadroom !== null && memoryHeadroom >= 0
+                      ? `Fits with ${formatNumber(memoryHeadroom, 2)} GB headroom.`
+                      : 'Model does not fit on the selected GPU.'}
+                  </p>
+                )}
+              </div>
+
+              {recommendedGpuList.length > 0 && (
+                <div className='mt-4 text-sm'>
+                  <p className='font-semibold text-base-content/70'>
+                    Closest matching GPUs
+                  </p>
+                  <ul className='mt-2 space-y-1'>
+                    {recommendedGpuList.map((gpu) => (
+                      <li key={gpu.name} className='flex justify-between'>
+                        <span>{gpu.name}</span>
+                        <span className='text-base-content/70'>
+                          {formatNumber(gpu.memoryHeadroomGB, 2)} GB spare
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
             </div>
 
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Select GPU</span>
-                <span className='tooltip tooltip-right' data-tip="Select a GPU to estimate inference time. TFLOPs and Memory Bandwidth will be auto-filled.">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
-              <select
-                className='select select-bordered w-full'
-                value={selectedGpuName}
-                onChange={(e) => {
-                  const selectedName = e.target.value;
-                  const selectedGpu = gpus.find(gpu => gpu.name === selectedName);
-                  if (selectedGpu) {
-                    setSelectedGpuName(selectedName);
-                    setGpuTFlops(parseFloat(selectedGpu.flops.split(' ')[0]));
-                    setMemoryBandwidth(parseFloat(selectedGpu.memory.split(' ')[0]));
-                  }
-                }}
-              >
-                {gpus.map((gpu) => (
-                  <option key={gpu.name} value={gpu.name}>
-                    {gpu.name} ({gpu.flops}, {gpu.memory})
-                  </option>
-                ))}
-              </select>
+            <div className='rounded-xl border border-base-300 bg-base-100 p-6 shadow-lg'>
+              <h2 className='text-xl font-semibold'>Performance</h2>
+              <div className='mt-4 grid gap-4 text-sm md:grid-cols-2'>
+                <label className='flex flex-col'>
+                  Kernel efficiency
+                  <input
+                    className='input input-bordered mt-1'
+                    type='number'
+                    min='0.05'
+                    max='1'
+                    step='0.05'
+                    value={efficiency}
+                    onChange={(event) =>
+                      setEfficiency(Number(event.target.value) || 0.3)
+                    }
+                  />
+                </label>
+                <div className='rounded-lg bg-base-200 p-3'>
+                  <p>
+                    <span className='font-semibold'>GPU FP32 throughput:</span>{' '}
+                    {selectedGpu?.fp32_tflops
+                      ? `${formatNumber(selectedGpu.fp32_tflops, 1)} TFLOPs`
+                      : 'N/A'}
+                  </p>
+                  <p className='text-xs text-base-content/70'>
+                    Adjust the efficiency multiplier to reflect framework and kernel
+                    optimisations.
+                  </p>
+                </div>
+              </div>
+
+              <div className='mt-4 space-y-3 text-sm'>
+                <p>
+                  <span className='font-semibold'>Estimated FLOPs / sequence:</span>{' '}
+                  {flops ? `${formatNumber(flops / 10 ** 12, 2)} TFLOPs` : 'N/A'}
+                </p>
+                <p>
+                  <span className='font-semibold'>Tokens per second:</span>{' '}
+                  {throughput.tokensPerSecond
+                    ? formatNumber(throughput.tokensPerSecond, 2)
+                    : 'N/A'}
+                </p>
+                <p>
+                  <span className='font-semibold'>Milliseconds per token:</span>{' '}
+                  {throughput.millisecondsPerToken
+                    ? formatNumber(throughput.millisecondsPerToken, 2)
+                    : 'N/A'}
+                </p>
+              </div>
             </div>
 
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>GPU TFlops (Selected)</span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full bg-gray-100 dark:bg-gray-700'
-                type='number'
-                value={gpuTFlops}
-                readOnly
-              />
-            </div>
-
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>GPU Memory Bandwidth (GB/s - Selected)</span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full bg-gray-100 dark:bg-gray-700'
-                type='number'
-                value={memoryBandwidth}
-                readOnly
-              />
-            </div>
-
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Model Parameters (Billions)</span>
-                <span className='tooltip tooltip-right' data-tip="Should match the 'Parameter Size' from the Memory Estimator.">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full'
-                placeholder='Number of Model Parameters (Billions)'
-                type='number'
-                onChange={(e) => {
-                  setNumParams(parseFloat(e.target.value) || 0);
-                }}
-                value={numParams}
-              />
-            </div>
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Software Overhead Factor</span>
-                <span className='tooltip tooltip-right' data-tip="Accounts for inefficiencies or variations in software stack and implementation. Typically between 1.1 (very optimized) and 1.5 (less optimized).">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full'
-                placeholder='Overhead Factor'
-                type='number'
-                onChange={(e) => {
-                  setOverheadFactor(parseFloat(e.target.value) || 1.0);
-                }}
-                value={overheadFactor}
-              />
-            </div>
-          </div>
-          <p className='mt-4'>
-            Estimated Inference Time:{' '}
-            <span className='font-bold text-lg'>
-              {formatInferenceTime(
-                estimateInferenceTime(
-                  calculatedGFlops,      // GFLOPs from FLOPs estimator
-                  gpuTFlops,             // TFLOPs from selected GPU
-                  numParams * 10 ** 9,   // Actual number of parameters
-                  memoryBandwidth,       // GB/s from selected GPU
-                  overheadFactor,
-                  bytes / 8              // bytes_per_param from model precision
-              ))}
-            </span>
-            {/* Removed "in seconds" as formatInferenceTime now includes units */}
-          </p>
-        </div>
-
-        <div className='m-5 rounded-lg border-2 border-black p-5'>
-          <h2>Cloud Training Estimator</h2>
-          <p className='mb-4'>Estimate the cost of training a model on Cloud Services</p>
-          <div className='flex flex-col space-y-4'> {/* Added space-y-4 */}
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Calculated GFLOPs (from FLOPs Estimator)</span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full bg-gray-100 dark:bg-gray-700' // Made read-only distinct
-                type='number'
-                value={calculatedGFlops.toFixed(2)}
-                readOnly
-              />
-            </div>
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Select Training GPU</span>
-                <span className='tooltip tooltip-right' data-tip="Select the GPU used for training. TFLOPs and Memory Bandwidth will be auto-filled.">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
-              <select
-                className='select select-bordered w-full'
-                value={selectedTrainingGpuName}
-                onChange={(e) => {
-                  const selectedName = e.target.value;
-                  const selectedGpu = gpus.find(gpu => gpu.name === selectedName);
-                  if (selectedGpu) {
-                    setSelectedTrainingGpuName(selectedName);
-                  setTrainingGpuTFlops(selectedGpu.fp32_tflops);
-                  setTrainingMemoryBandwidth(selectedGpu.memory_bandwidth_gb_s);
-                  }
-                }}
-              >
-                {gpus.map((gpu) => (
-                  <option key={gpu.name} value={gpu.name}>
-                  {gpu.name} (Memory: {gpu.memory_gb}GB, TFLOPs: {gpu.fp32_tflops}, BW: {gpu.memory_bandwidth_gb_s}GB/s)
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Training GPU TFlops (Selected)</span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full bg-gray-100 dark:bg-gray-700'
-                type='number'
-                value={trainingGpuTFlops}
-                readOnly
-              />
-            </div>
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Training GPU Memory Bandwidth (GB/s - Selected)</span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full bg-gray-100 dark:bg-gray-700'
-                type='number'
-                value={trainingMemoryBandwidth}
-                readOnly
-              />
-            </div>
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Model Parameters (Billions)</span>
-                <span className='tooltip tooltip-right' data-tip="Should match 'Parameter Size' from Memory Estimator.">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full'
-                placeholder='Number of Model Parameters (Billions)'
-                type='number'
-                onChange={(e) => {
-                  setNumParams(parseFloat(e.target.value) || 0);
-                }}
-                value={numParams}
-              />
-            </div>
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>GPU Hourly Cost</span>
-                <span className='tooltip tooltip-right' data-tip="The cost per hour for the selected training GPU, in your currency (e.g., USD).">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full'
-                placeholder='GPU Hourly Cost'
-                type='number'
-                onChange={(e) => {
-                  setGpuHourlyCost(parseFloat(e.target.value) || 0);
-                }}
-                value={gpuHourlyCost}
-              />
-            </div>
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Number of Epochs</span>
-                <span className='tooltip tooltip-right' data-tip="The total number of times the model will iterate over the entire training dataset.">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full'
-                placeholder='Number of Epochs'
-                type='number'
-                onChange={(e) => {
-                  setNumEpochs(parseFloat(e.target.value) || 0);
-                }}
-                value={numEpochs}
-              />
-            </div>
-            <div className='form-control w-full'>
-              <label className='label'>
-                <span className='label-text'>Datakset Size</span>
-                <span className='tooltip tooltip-right' data-tip="Total number of training examples (sequences/items) in your dataset.">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-info shrink-0 w-4 h-4 ml-1 cursor-pointer"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                </span>
-              </label>
-              <input
-                className='input input-bordered input-primary w-full'
-                placeholder='Dataset Size'
-                type='number'
-                onChange={(e) => {
-                  setDatasetSize(parseFloat(e.target.value) || 0);
-                }}
-                value={datasetSize}
-              />
+            <div className='rounded-xl border border-base-300 bg-base-100 p-6 shadow-lg'>
+              <h2 className='text-xl font-semibold'>Cloud cost projection</h2>
+              <div className='mt-4 grid gap-4 text-sm md:grid-cols-2'>
+                <label className='flex flex-col'>
+                  Cloud instance
+                  <select
+                    className='select select-bordered mt-1'
+                    value={selectedInstanceName}
+                    onChange={(event) =>
+                      setSelectedInstanceName(event.target.value)
+                    }
+                  >
+                    {cloudInstances.map((instance) => (
+                      <option key={instance.name} value={instance.name}>
+                        {instance.provider} {instance.name} ({instance.gpu})
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className='flex flex-col'>
+                  Runtime (hours)
+                  <input
+                    className='input input-bordered mt-1'
+                    type='number'
+                    min='0'
+                    step='0.25'
+                    value={runtimeHours}
+                    onChange={(event) =>
+                      setRuntimeHours(Number(event.target.value) || 0)
+                    }
+                  />
+                </label>
+                <label className='flex flex-col'>
+                  Custom hourly rate (optional)
+                  <input
+                    className='input input-bordered mt-1'
+                    type='number'
+                    min='0'
+                    step='0.01'
+                    value={customHourlyRate === '' ? '' : customHourlyRate}
+                    onChange={(event) => {
+                      const value = event.target.value;
+                      setCustomHourlyRate(value ? Number(value) : '');
+                    }}
+                  />
+                </label>
+                <div className='rounded-lg bg-base-200 p-3'>
+                  <p>
+                    <span className='font-semibold'>Effective hourly rate:</span>{' '}
+                    ${formatNumber(hourlyRate, 2)}
+                  </p>
+                  <p>
+                    <span className='font-semibold'>Estimated cost:</span>{' '}
+                    ${formatNumber(costEstimate.totalCost, 2)}
+                  </p>
+                </div>
+              </div>
             </div>
           </div>
-          <p className='mt-4'>
-            Estimated Cloud Training Cost: $
-            <span className='font-bold text-lg'>
-              {estimateTrainingCost(
-                calculatedGFlops,          // GFLOPs from FLOPs estimator
-                trainingGpuTFlops,         // TFLOPs from selected training GPU
-                numParams * 10 ** 9,       // Actual number of parameters
-                trainingMemoryBandwidth,   // GB/s from selected training GPU
-                overheadFactor,
-                gpuHourlyCost,
-                numEpochs,
-                datasetSize,
-                bytes                        // model_precision_bits (e.g. 16 or 32)
-              ).toFixed(2)}
-            </span>{' '}
-          </p>
-        </div>
+        </section>
       </div>
     </main>
   );
 }
+
+function parseModelConfig(config: Record<string, unknown>): ModelMetadata {
+  const directParamKeys = [
+    'num_parameters',
+    'n_parameters',
+    'n_params',
+    'num_params',
+    'total_params',
+    'model_size',
+  ];
+
+  let parameterCount = 0;
+  for (const key of directParamKeys) {
+    const value = safeNumber(config[key]);
+    if (value && value > 0) {
+      parameterCount = value;
+      break;
+    }
+  }
+
+  if (!parameterCount && typeof config.model === 'object' && config.model !== null) {
+    const nested = config.model as Record<string, unknown>;
+    const nestedCount = safeNumber(nested.num_parameters);
+    if (nestedCount && nestedCount > 0) {
+      parameterCount = nestedCount;
+    }
+  }
+
+  const hiddenSize =
+    safeNumber(config.hidden_size) ?? safeNumber(config.d_model) ?? 0;
+  const numLayers =
+    safeNumber(config.num_hidden_layers) ??
+    safeNumber(config.num_layers) ??
+    safeNumber(config.n_layer) ??
+    0;
+  const numHeads =
+    safeNumber(config.num_attention_heads) ??
+    safeNumber(config.num_heads) ??
+    safeNumber(config.n_head) ??
+    0;
+  const intermediateSize =
+    safeNumber(config.intermediate_size) ??
+    safeNumber(config.ffn_dim) ??
+    safeNumber(config.d_ff);
+  const sequenceLength =
+    safeNumber(config.max_position_embeddings) ??
+    safeNumber(config.seq_length) ??
+    safeNumber(config.n_positions);
+  const vocabSize = safeNumber(config.vocab_size);
+  const kvHeads =
+    safeNumber(config.num_key_value_heads) ?? safeNumber(config.n_head_kv);
+
+  if (!parameterCount && hiddenSize && numLayers && numHeads && vocabSize) {
+    parameterCount = estimateTransformerParameters({
+      vocabSize,
+      hiddenSize,
+      numLayers,
+      numAttentionHeads: numHeads,
+      intermediateSize,
+      numKeyValueHeads: kvHeads ?? undefined,
+    });
+  }
+
+  const dtypeRaw = config.torch_dtype as string | undefined;
+  const dtypeBits: PrecisionBits | undefined = (() => {
+    switch (dtypeRaw) {
+      case 'float32':
+      case 'torch.float32':
+        return 32;
+      case 'float16':
+      case 'torch.float16':
+      case 'bfloat16':
+      case 'torch.bfloat16':
+        return 16;
+      case 'int8':
+        return 8;
+      case 'int4':
+        return 4;
+      default:
+        return undefined;
+    }
+  })();
+
+  return {
+    parameterCount,
+    hiddenSize: hiddenSize ?? 0,
+    numLayers: numLayers ?? 0,
+    numHeads: numHeads ?? 0,
+    intermediateSize: intermediateSize ?? undefined,
+    sequenceLength: sequenceLength ?? undefined,
+    vocabSize: vocabSize ?? undefined,
+    dtypeBits,
+  };
+}
+


### PR DESCRIPTION
## Summary
- add llama-style architecture heuristics for parameter-only estimates and cover them with unit tests
- redesign the quick estimator workflow with mode-specific controls, concurrency slider, and manual architecture overrides
- surface contextual VRAM messaging, KV precision emphasis, and kernel efficiency tuning to clarify inference vs. training assumptions

## Testing
- npm test
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69148731eb808333802a026062a9cdc8)